### PR TITLE
Add "style" key to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "axios-feta",
   "version": "0.0.1",
   "description": "Axios' CSS styleguide and library.",
+  "style": "src/feta.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/axioscode/feta/"


### PR DESCRIPTION
Adding the `style` key will allow us to use some CSS/SCSS libraries (like [`sass-module-importer`](https://www.npmjs.com/package/sass-module-importer) or–with a little more work–[`postcss-import`](https://github.com/postcss/postcss-import)) and then just have `@import "axios-feta";` work as expected.